### PR TITLE
eaf components & license

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,34 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 ```
+
+## eaf components
+
+- **eaf**: Module that contains the main implementation of the crate for reading and writing EAF files.
+- **pfsx**: Module that provides functionality for parsing ELAN preference files.
+- **ffmpeg**: Module that offers functionality related to FFmpeg, a multimedia library used in ELAN.
+- **EafError**: Crate-specific error type for handling EAF-related errors.
+- **Eaf**: Main structure that represents an EAF file and provides methods for deserialization and manipulation.
+- **Scope**: Enumeration that describes the possible scopes of an EAF object.
+- **License**: Structure that represents the license associated with an EAF file.
+- **Header**: Structure that contains header information of an EAF file.
+- **MediaDescriptor**: Structure that describes a media (e.g., audio or video file) used in an EAF file.
+- **Property**: Structure that represents a property associated with an EAF object.
+- **TimeOrder**: Structure that defines the order of time objects in an EAF file.
+- **TimeSlot**: Structure that represents a timestamp in an EAF file.
+- **Tier**: Structure that represents a tier (layer) in an EAF file.
+- **Annotation**: Structure that represents an annotation in an EAF file.
+- **LinguisticType**: Structure that describes the linguistic type of a tier in an EAF file.
+- **Constraint**: Structure that defines a constraint in an EAF file.
+- **StereoType**: Enumeration that describes the possible stereotypes of a tier in an EAF file.
+- **Language**: Structure that represents the language used in an EAF file.
+- **LexiconRef**: Structure that references a lexicon in an EAF file.
+- **Index**: Structure that provides indices to access objects in an EAF file.
+- **Locale**: Structure that represents the regional settings used in an EAF file.
+- **ControlledVocabulary**: Structure that defines a controlled vocabulary in an EAF file.
+- **JsonAnnotation**: Structure that represents an annotation in JSON format.
+
+
+## License
+
+This project is licensed under the MIT License. See the  [LICENSE](https://github.com/jenslar/eaf-rs/blob/main/LICENSE.txt) file for more details.


### PR DESCRIPTION
Hi,
 
The purpose of this request is to add the components of the eaf-rs crate and include the appropriate license information in the README file. I believe this addition will greatly benefit the project by providing clarity and ensuring proper compliance. Please review the changes at your earliest convenience and let me know if any further modifications are required.